### PR TITLE
Fix URL for dipfit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://arnodelorme@github.com/widmann/firfilt.git
 [submodule "plugins/dipfit"]
 	path = plugins/dipfit
-	url = git@github.com:eeglabdevelopers/dipfit.git
+	url = https://github.com/eeglabdevelopers/dipfit.git


### PR DESCRIPTION
The URL for the dipfit repo is incorrect, causing git clone --recurse-submodules to fail to download dipfit when following the instructions for getting eeglab. This edit contains the correct (https) URL to clone dipfit into the eeglab/plugins/dipfit directory.