### PR TITLE
Update readlocs.m fidnames

### DIFF
--- a/functions/sigprocfunc/readlocs.m
+++ b/functions/sigprocfunc/readlocs.m
@@ -602,7 +602,7 @@ end
 
 % process fiducials if any
 % ------------------------
-fidnames = { 'nz' 'lpa' 'rpa' 'nasion' 'left' 'right' 'nazion' 'fidnz' 'fidt9' 'fidt10' 'cms' 'drl' };
+fidnames = { 'nz' 'lpa' 'rpa' 'nasion' 'left' 'right' 'nazion' 'fidnz' 'fidt9' 'fidt10' 'cms' 'drl' 'nas' 'lht' 'rht' };
 for index = 1:length(fidnames)
     ind = strmatch(fidnames{index}, lower(labels), 'exact');
     if ~isempty(ind), eloc(ind).type = 'FID'; end


### PR DESCRIPTION
Include fiducial names used by get_chanlocs plug-in. nasion (nas), and left and right helix/tragus interface (lht, rht).