### PR TITLE
Adds EEG start datetime (from fileio) for clinical EEGs

### DIFF
--- a/functions/popfunc/pop_fileio.m
+++ b/functions/popfunc/pop_fileio.m
@@ -204,6 +204,9 @@ EEG.comments        = [ 'Original file: ' filename ];
 EEG.xmin = -dat.nSamplesPre/EEG.srate; 
 EEG.trials          = dat.nTrials;
 EEG.pnts            = dat.nSamples;
+if isfield(dat,'startDateTime')
+    EEG.startDateTime = dat.startDateTime;
+end
 if isfield(dat, 'label') && ~isempty(dat.label)
     EEG.chanlocs = struct('labels', dat.label);
     


### PR DESCRIPTION
I've added some Nicolet reading code to fieldtrip ([the pull request](https://github.com/fieldtrip/fieldtrip/pull/302)). For clinical purposes we would like to have the start datetime of the EEG. This code sets a field EEG.startDateTime if the same field is present when reading with fieldtrip.

Please correct me if EEG.startDateTime is not the correct place to store this information.