### PR TITLE
the option takes highpass as a str

### DIFF
--- a/functions/studyfunc/std_preclust.m
+++ b/functions/studyfunc/std_preclust.m
@@ -472,7 +472,10 @@ function cluster = checkcentroidfield(cluster, varargin);
     
     % rapid filtering for ERP (from std_plotcurve)
 % -----------------------
-function tmpdata2 = myfilt(tmpdata, srate, lowpass, highpass); 
+function tmpdata2 = myfilt(tmpdata, srate, lowpass, highpass);
+if ischar(highpass)
+    highpass = str2num(highpass);
+end
     bscorrect = 1;
     if bscorrect
         % Getting initial baseline


### PR DESCRIPTION
If process the pca step under study option. The input in lowpass ERP will make highpass a string.
It will cause but in line 488 for function eegfiltfft.
It needs to be a num for eegfiltfft to work.
Add this fix will make the option work corretly.