### PR TITLE
Fixed a bug where column-wise labels were not imported.

### DIFF
--- a/functions/sigprocfunc/readeetraklocs.m
+++ b/functions/sigprocfunc/readeetraklocs.m
@@ -73,8 +73,12 @@ function chanlocs = readeetraklocs( filename )
     % get positions
     %----------------
     positions = locs(indpos + 1:indlabels-1,:);
-    labels    = locs(end,:);
-    labels(strcmp(labels, 'Labels')) = [];     
+    
+    % get labels
+    %----------------
+    labels      = locs(indlabels:end,:);
+    labels(strcmp(labels, 'Labels')) = [];  
+    labels      =  labels(~cellfun('isempty',labels));
     
     % remove all non-numbers from positions 
     %----------------


### PR DESCRIPTION
Function finds all labels after label header, independent of row- or column-wise arrangement.