### PR TITLE
change eegplot default rejection for continuous vs. epoched data

### DIFF
--- a/eeglab.m
+++ b/eeglab.m
@@ -612,7 +612,7 @@ cb_topoblank1  = [ checkplot 'LASTCOM = [''figure; topoplot([],EEG.chanlocs, '''
                    '''''electrodes'''', ''''labelpoint'''', ''''chaninfo'''', EEG.chaninfo);'']; eval(LASTCOM);' e_hist];
 cb_topoblank2  = [ checkplot 'LASTCOM = [''figure; topoplot([],EEG.chanlocs, ''''style'''', ''''blank'''',  ' ...
                    '''''electrodes'''', ''''numpoint'''', ''''chaninfo'''', EEG.chaninfo);'']; eval(LASTCOM);' e_hist];
-cb_eegplot1    = [ check         'LASTCOM = pop_eegplot(EEG, 1, 1, 1);'   e_hist];
+cb_eegplot1    = [ check         'LASTCOM = pop_eegplot(EEG, 1, 1, EEG.trials==1);'   e_hist];
 cb_spectopo1   = [ check         'LASTCOM = pop_spectopo(EEG, 1);'        e_hist];
 cb_prop1       = [ checkplot     'LASTCOM = pop_prop(EEG,1);'             e_hist];
 cb_erpimage1   = [ checkepoch    'LASTCOM = pop_erpimage(EEG, 1, eegh(''find'',''pop_erpimage(EEG,1''));' e_hist];


### PR DESCRIPTION
With continuous data, GUI>Plot>Channel data (scroll), pops up with a REJECT button for rejecting manually selected continuous data, this is fine*. 

With epoched data, GUI>Plot>Channel data (scroll), pops up again with a REJECT button. This does not allow the user to update epochs marked for rejection manually, instead they must either reject old+new marks, or they have to close the window and use GUI > Tools > Reject data epochs >Reject by inspection to update the marks without rejecting. With this change, GUI>Plot>Channel data (scroll), pops up with an UPDATE MARKS** button, and gives the usual follow-up message to use GUI > Tools > Reject data epochs >Reject marked epochs if any changes are made. 

This has the added benefit of directing users who might only use Plot > Channel data (scroll) for cleaning data to the Tools > Reject data epochs menu. Ideally these functions should be identical or completely separate (e.g. Plot is for fast data viz and no cleaning, and Tools > Reject is for cleaning). I'd prefer they be identical/merged.

*Although, it would be nice to be able to save continuous data marked for deletion rather than being forced to reject it each time eegplot is used. Perhaps EEG.reject.rejmanual could be changed to save sample indices rather than epoch indices for continuous data.
**While also respecting the REJECT option for continuous data