### PR TITLE
Fix pop_subcomp ignoring the components arg

### DIFF
--- a/functions/popfunc/pop_subcomp.m
+++ b/functions/popfunc/pop_subcomp.m
@@ -78,8 +78,9 @@ if nargin < 3
 	plotag = 0;
 end
 if nargin == 4 && ismember(keepcomp,[1 0]); keep_flag = keepcomp; if isempty(plotag) plotag = 0; end;  else keep_flag = 0; end
-components = [];
+
 if nargin < 2
+    components = [];
 	% popup window parameters
 	% -----------------------
     res = 'Manual rej.';


### PR DESCRIPTION
Since ecc6e47f04ff257e0362d0423510de4345d4da2b, `pop_subcomp` emptied the components arg so previously working code like `EEG = pop_subcomp( EEG, 1:5, 0, 1)` did nothing.