### PR TITLE
pop_subcomp: fix list of components to keep for multiple datasets

### DIFF
--- a/functions/popfunc/pop_subcomp.m
+++ b/functions/popfunc/pop_subcomp.m
@@ -141,7 +141,7 @@ if length(EEG) > 1
     if nargin < 2
         [ EEG, com ] = eeg_eval( 'pop_subcomp', EEG, 'warning', 'on', 'params', { components } );
     else
-        [ EEG, com ] = eeg_eval( 'pop_subcomp', EEG, 'params', { components } );
+        [ EEG, com ] = eeg_eval( 'pop_subcomp', EEG, 'params', { components, plotag, keepcomp } );
     end
     if isempty( components )
         com = [ com ' % [] or '' means removing components flaged for rejection' ];


### PR DESCRIPTION
Same as f62a404740c3a37b785c6ed085e0138875a511f9 / #210 but for multiple datasets.