### PR TITLE
Add .gitignore so git ignores contents of manually installed plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore everything in plugin folders, but keep track of plugin submodules 
+/plugins/*/**
+!/plugins/*


### PR DESCRIPTION
For my local installation, git sees about 4800 changed files because I installed a few plugins with the eeglab plugin manager. The .gitignore below configures git the ignore the contents of plugin folders that aren't submodules.

Changing files and checking out different commits in submodule folders is still tracked correctly.