### PR TITLE
Add Octave support to plugin installation

### DIFF
--- a/functions/adminfunc/plugin_getweb.m
+++ b/functions/adminfunc/plugin_getweb.m
@@ -39,8 +39,12 @@ if isfield(pluginOri, 'plugin'), pluginOri = plugin_convert(pluginOri); end
 % retreiving statistics
 try
     disp( [ 'Retreiving download statistics...' ] );
-    [stats, status] = plugin_urlread('http://sccn.ucsd.edu/eeglab/plugin_uploader/plugin_getcountall_nowiki.php');
-    stats = textscan(stats, '%s%d%s%s%f%d%s%s%s%s%s%f', 'delimiter', char(9));
+    if exist('OCTAVE_VERSION', 'builtin') == 0
+        [stats, status] = plugin_urlread('http://sccn.ucsd.edu/eeglab/plugin_uploader/plugin_getcountall_nowiki.php');
+    else
+        [stats, status] = urlread('http://sccn.ucsd.edu/eeglab/plugin_uploader/plugin_getcountall_nowiki.php');
+    end
+    stats = textscan(stats, '%s%d%s%s%f%d%s%s%s%s%s%s', 'delimiter', char(9));
     if length(unique(cellfun(@length, stats))) > 1
         disp('Issue with retrieving statistics for extensions');
         return;
@@ -77,7 +81,7 @@ for iRow = 1:length(stats{1})
     plugin(iRow).contactname  = stats{9}{iRow};
     plugin(iRow).contactemail = stats{10}{iRow};
     plugin(iRow).webdoc    = stats{11}{iRow};
-    plugin(iRow).size      = stats{12}(iRow);
+    plugin(iRow).size      =  sscanf(stats{12}{iRow}, '%f'); % Only numeric part is taken, possible KB or MB additions are ignored
     plugin(iRow).webrating = [ 'https://sccn.ucsd.edu/eeglab/plugin_uploader/simplestar.php?plugin=' plugin(iRow).name '&version=' plugin(iRow).version ];
     
     % match with existiting plugins

--- a/functions/adminfunc/plugin_install.m
+++ b/functions/adminfunc/plugin_install.m
@@ -70,8 +70,13 @@ function result = plugin_install(zipfilelink, name, version, pluginsize, forceIn
     end
          
     try
-        plugin_urlread(['http://sccn.ucsd.edu/eeglab/plugin_uploader/plugin_increment.php?plugin=' name '&version=' version ]);
-        plugin_urlwrite( zipfilelink, fullfile(generalPluginPath, zipfile));
+        if exist('OCTAVE_VERSION', 'builtin') == 0
+            plugin_urlread(['http://sccn.ucsd.edu/eeglab/plugin_uploader/plugin_increment.php?plugin=' name '&version=' version ]);
+            plugin_urlwrite( zipfilelink, fullfile(generalPluginPath, zipfile));
+        else
+            urlread(['http://sccn.ucsd.edu/eeglab/plugin_uploader/plugin_increment.php?plugin=' name '&version=' version ]);
+            urlwrite( zipfilelink, fullfile(generalPluginPath, zipfile));
+        end
     catch
         msg = [ 'Could not download extension. Host site might be' 10 ...
                 'unavailable, too slow or you do not have permission' 10 ...

--- a/functions/adminfunc/plugin_urlread.m
+++ b/functions/adminfunc/plugin_urlread.m
@@ -36,6 +36,8 @@ if exist('OCTAVE_VERSION', 'builtin') == 0
     com.mathworks.mlwidgets.html.HTMLPrefs.setProxySettings
 end
 
+
+
 % Check number of inputs and outputs.
 if ~ischar(urlChar)
     error('MATLAB:urlread:InvalidInput','The first input, the URL, must be a character array.');


### PR DESCRIPTION
Fixes #240 
Due to java calls in `plugin_urlread` and `plugin_urlwrite` functions
and the use of libraries `com.mathworks.mlwidgets.io.InterruptibleStreamCopier`
and `com.mathworks.mlwidgets.html.HTMLPrefs.setProxySettings`, `plugin_install`
and `plugin_askinstall` cannot be used with GNU Octave.
This is solved by using the built-in `urlread` and `urlwrite` functions
if Octave is detected. The textscan format in `plugin_getweb` is also
updated to correctly parse the plugin sizes if they are succeeded by an
optional 'KB' or 'MB', which is handled differently in Octave and in
Matlab. Currently, these 'KB' and 'MB' size specifications are ignored,
which was also the case earlier.