### PR TITLE
Replace deprecated strmatch occurrence with strcmp

### DIFF
--- a/functions/popfunc/pop_epoch.m
+++ b/functions/popfunc/pop_epoch.m
@@ -236,7 +236,7 @@ if ~isempty( events )
 			for index2 = 1:length( events )
 				tmpevent = events{index2};
 				if ~ischar( tmpevent ), tmpevent = num2str( tmpevent ); end
-				Ieventtmp = [ Ieventtmp ; strmatch(deblank(tmpevent), tmpeventtype, 'exact') ];
+				Ieventtmp = [ Ieventtmp ; find(strcmp(deblank(tmpevent), tmpeventtype))' ];
 			end
 		else
 			for index2 = 1:length( events )


### PR DESCRIPTION
Fix #249
The use of strmatch has been deprecated. Additionally, strmatch behaves
differently in Octave and Matlab (different output dimension), which
sometimes causes event finding to crash in Octave.