### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ignore everything in plugin folders, but keep track of plugin submodules 
-/plugins/*/**
-!/plugins/*
-/plugins/mffmatlabio
+/plugins/**
+!/plugins/clean_rawdata
+!/plugins/dipfit
+!/plugins/firfilt
+!/plugins/ICLabel
 .DS_Store


### PR DESCRIPTION
ignoring /plugins/** might work better since that's where most plugins go? Explicitly defined exceptions for the submodules