### PR TITLE
Fixing bug: deleting n>1 datasets throws error, e.g. pop_delset(ALLEEG,[2,3])

### DIFF
--- a/functions/adminfunc/pop_delset.m
+++ b/functions/adminfunc/pop_delset.m
@@ -54,7 +54,7 @@ if isempty( ALLSET )
     return;
 end;    
 
-if nargin < 2 || set_in < 0
+if nargin < 2 || (length(set_in)==1 && set_in < 0)
 	% which set to delete
 	% -----------------
 	promptstr    = { 'Dataset(s) to delete:' };


### PR DESCRIPTION
Currently pop_delset can not delete more than one datasets if called from the command line with a vector of numeric dataset indices; this is an attempt to fix this. Note that this behavior is assumed by the string command output of the function itself when using in the GUI. E.g. I deleted datasets 2 and 3 in the GUI, end the eegh command yielded:

[...]
EEG = pop_delset( EEG, [2  3] );

