### PR TITLE
read EEG.event.trial_type to find events

### DIFF
--- a/functions/popfunc/pop_epoch.m
+++ b/functions/popfunc/pop_epoch.m
@@ -243,8 +243,15 @@ if ~isempty( events )
 			for index2 = 1:length( events )
 				tmpevent = events{index2};
 				if ischar( tmpevent ),tmpevent = str2num( tmpevent ); end
-				if isempty( tmpevent ), error('pop_epoch(): string entered in a numeric field'); end
-				Ieventtmp = [ Ieventtmp find(tmpevent == [ tmpeventtype{:} ]) ];
+				if isempty( tmpevent ) 
+                    try
+                        tmpevent = unique(cell2mat(tmpeventtype(arrayfun(@(x) strcmpi(x.trial_type,events{index2}),EEG.event))));
+                        fprintf('using EEG.event.trial_type %s to match event input\n',events{index2})
+                    catch 
+                        error('pop_epoch(): string entered in a numeric field'); 
+                    end
+                    Ieventtmp = [ Ieventtmp find(tmpevent == [ tmpeventtype{:} ]) ];
+                end
 			end
 		end
     else


### PR DESCRIPTION
seems like a bug importing events from BIDS matlab tools -- a discrepency betwen event.type (num expected char) and event.trial_type (char) , solved by trying to read trial_type if num2str returns an empty array