### PR TITLE
pop_saveset: fix bug in 'twofiles' writing

### DIFF
--- a/functions/popfunc/pop_saveset.m
+++ b/functions/popfunc/pop_saveset.m
@@ -212,6 +212,7 @@ else
     if strcmpi(g.savemode, 'twofiles')
         save_as_dat_file = 1;
         EEG.datfile = [ filenamenoext '.fdt' ];
+        option_savetwofiles = true; % BUG: Missing, thus it will save data in .set file as well as fdt
     end
 end
 


### PR DESCRIPTION
the twofiles option was not handled completely. 

It was writing an .fdt _and_ then saved the data in .set.