### PR TITLE
Update finputcheck.m

### DIFF
--- a/functions/guifunc/finputcheck.m
+++ b/functions/guifunc/finputcheck.m
@@ -210,6 +210,9 @@ function g = fieldtest( fieldname, fieldtype, fieldval, tmpval, callfunc );
       
       
      case 'string'
+      if isstring(tmpval)
+          tmpval = convertStringsToChars(tmpval);
+      end
       if ~ischar(tmpval) && ~isempty(tmpval)
           g = [ callfunc 'error: argument ''' fieldname ''' must be a string' ]; return;
       end


### PR DESCRIPTION
The function was implemented inconsistently. For example, "pop_saveset" requires strings as values. But this function would throw an error when a string is passed, as it only accepts char arrays. Now strings are being converted to char arrays before that.