### PR TITLE
Fix typos found by codespell

### DIFF
--- a/functions/statistics/statcond.m
+++ b/functions/statistics/statcond.m
@@ -46,11 +46,11 @@
 %   'naccu'    = [integer] Number of surrogate data copies to use in 'perm' 
 %                 or 'bootstrap' method estimation (see above) {default: 200}.
 %   'verbose'  = ['on'|'off'] print info on the command line {default: 'on'}.
-%   'variance' = ['homegenous'|'inhomogenous'] this option is exclusively
+%   'variance' = ['homogeneous'|'inhomogeneous'] this option is exclusively
 %                for parametric statistics using unpaired t-test. It allows
 %                to compute a more accurate value for the degree of freedom
-%                using the formula for inhomogenous variance (see
-%                ttest2_cell function). Default is 'inhomegenous'.
+%                using the formula for inhomogeneous variance (see
+%                ttest2_cell function). Default is 'inhomogeneous'.
 %   'surrog'   = surrogate data array (see output).
 %   'stats'    = F- or T-value array (see output).
 %   'tail'     = ['one'|'two'] run one-tailed (F-test) or two tailed
@@ -172,17 +172,17 @@ function [ ori_vals, df, pvals, surrogval ] = statcond( data, varargin );
         g = finputcheck( varargin, { 'naccu'      'integer'   [1 Inf]             200;
                                      'method'     'string'    { 'param','parametric','perm','permutation','bootstrap' }  'param';
                                      'mode'       'string'    { }                 '';
-                                     'paired'     'string'    { 'on','off','auto' }      'auto'; 
-                                     'surrog'     { 'real','cell' }      []       []; 
-                                     'stats'      { 'real','cell' }      []       []; 
-                                     'structoutput' 'string'  { 'on','off' }      'off'; 
-                                     'forceanova'   'string'  { 'on','off' }      'off'; 
-                                     'arraycomp'  'string'    { 'on','off' }      'on'; 
-                                     'cluster'    'string'    { 'on','off' }      'off'; 
+                                     'paired'     'string'    { 'on','off','auto' }      'auto';
+                                     'surrog'     { 'real','cell' }      []       [];
+                                     'stats'      { 'real','cell' }      []       [];
+                                     'structoutput' 'string'  { 'on','off' }      'off';
+                                     'forceanova'   'string'  { 'on','off' }      'off';
+                                     'arraycomp'  'string'    { 'on','off' }      'on';
+                                     'cluster'    'string'    { 'on','off' }      'off';
                                      'alpha'      'real'      []                  NaN;
-                                     'tail'       'string'    { 'one','both','upper','lower'}    'both'; 
-                                     'variance'   'string'    { 'homogenous','inhomogenous' }    'inhomogenous'; 
-                                     'returnresamplingarray' 'string'    { 'on','off' }      'off'; 
+                                     'tail'       'string'    { 'one','both','upper','lower'}    'both';
+                                     'variance'   'string'    { 'homogeneous','inhomogeneous', 'homogenous','inhomogenous' }    'inhomogeneous';
+                                     'returnresamplingarray' 'string'    { 'on','off' }      'off';
                                      'verbose'    'string'    { 'on','off' }      'on' }, 'statcond');
         if ischar(g), error(g); end
     else
@@ -195,7 +195,7 @@ function [ ori_vals, df, pvals, surrogval ] = statcond( data, varargin );
         if ~isfield(g, 'arraycomp'), g.arraycomp = 'on'; end
         if ~isfield(g, 'verbose'),   g.verbose = 'on'; end
         if ~isfield(g, 'tail'),      g.tail = 'both'; end
-        if ~isfield(g, 'variance'),  g.variance = 'homogenous'; end
+        if ~isfield(g, 'variance'),  g.variance = 'inhomogeneous'; end
         if ~isfield(g, 'structoutput'), g.structoutput = 'on'; end
         if ~isfield(g, 'returnresamplingarray'),   g.returnresamplingarray = 'off'; end
     end
@@ -213,6 +213,8 @@ function [ ori_vals, df, pvals, surrogval ] = statcond( data, varargin );
                '            Running nonparametric permutation tests\n.']);
       g.method = 'perm';
     end
+    if strcmpi(g.variance, 'homogenous'), g.variance = 'homogeneous'; end
+    if strcmpi(g.variance, 'inhomogenous'), g.variance = 'inhomogeneous'; end
     g.naccu = round(g.naccu);
     
     % pairing
@@ -559,11 +561,11 @@ function [f, df] = anova1_cell_select( res, paired)
 
 % compute t-test
 % -------------------
-function [t, df] = ttest_cell_select( res, paired, homogenous)
+function [t, df] = ttest_cell_select( res, paired, homogeneous)
     if strcmpi(paired,'on')
         [t, df] = ttest_cell( res{1}, res{2});
     else
-        [t, df] = ttest2_cell( res{1}, res{2}, homogenous);
+        [t, df] = ttest2_cell( res{1}, res{2}, homogeneous);
     end
 
 % function to compute the number of dimensions

--- a/functions/statistics/ttest2_cell.m
+++ b/functions/statistics/ttest2_cell.m
@@ -4,15 +4,15 @@
 % Usage:
 %    >> [F df] = ttest2_cell( { a b } );
 %    >> [F df] = ttest2_cell(a, b);
-%    >> [F df] = ttest2_cell(a, b, 'inhomogenous');
+%    >> [F df] = ttest2_cell(a, b, 'inhomogeneous');
 %
 % Inputs:
 %   a,b       = data consisting of UNPAIRED arrays to be compared. The last 
 %               dimension of the data array is used to compute the t-test.
-%   'inhomogenous' = use computation for the degree of freedom using 
-%                    inhomogenous variance. By default the computation of
-%                    the degree of freedom is done with homogenous
-%                    variances.
+%   'inhomogeneous' = use computation for the degree of freedom using
+%                     inhomogeneous variance. By default the computation of
+%                     the degree of freedom is done with homogeneous
+%                     variances.
 %
 % Outputs:
 %   T   - T-value
@@ -36,7 +36,7 @@
 %
 % Author: Arnaud Delorme, SCCN/INC/UCSD, La Jolla, 2005
 %         (thank you to G. Rousselet for providing the formula for 
-%         inhomogenous variances).
+%         inhomogeneous variances).
 %
 % Reference:
 %   Schaum's outlines in statistics (3rd edition). 1999. Mc Graw-Hill.
@@ -76,19 +76,21 @@ function [tval, df] = ttest2_cell(a,b,c) % assumes equal variances
         return;
     end
     
-    homogenous = 'homogenous';
+    homogeneous = 'homogeneous';
     if nargin > 1 && ischar(b)
-        homogenous = b;
+        homogeneous = b;
     end
     if nargin > 2 && ischar(c)
-        homogenous = c;
+        homogeneous = c;
     end
+    if strcmpi(homogeneous, 'homogenous'), homogeneous = 'homogeneous'; end
+    if strcmpi(homogeneous, 'inhomogenous'), homogeneous = 'inhomogeneous'; end
     if iscell(a), 
         b = a{2}; 
         a = a{1}; 
     end
-    if ~strcmpi(homogenous, 'inhomogenous') && ~strcmpi(homogenous, 'homogenous')
-        error('Value for homogenous parameter can only be ''homogenous'' or ''inhomogenous''');
+    if ~strcmpi(homogenous, 'inhomogeneous') && ~strcmpi(homogenous, 'homogeneous')
+        error('Value for homogenous parameter can only be ''homogeneous'' or ''inhomogeneous''');
     end
 
     nd    = myndims(a);
@@ -97,8 +99,8 @@ function [tval, df] = ttest2_cell(a,b,c) % assumes equal variances
     meana = mymean(a, nd);
     meanb = mymean(b, nd);
     
-    if strcmpi(homogenous, 'inhomogenous')
-        % inhomogenous variance from Howel, 2009, "Statistical Methods for Psychology"
+    if strcmpi(homogeneous, 'inhomogeneous')
+        % inhomogeneous variance from Howel, 2009, "Statistical Methods for Psychology"
         % thank you to G. Rousselet for providing these formulas
         m  = meana - meanb;
         s1 = var(a,0,nd) ./ na;

--- a/functions/studyfunc/std_rmdat.m
+++ b/functions/studyfunc/std_rmdat.m
@@ -24,7 +24,7 @@
 %                   in the selected range. May also be {'string' 'value'}
 %                   for non-numerical variables.
 %   'subjectind'  - [integer array] keep only specific subject indices in 
-%                   STUDY.subject. To remove or keep specificy subjects, 
+%                   STUDY.subject. To remove or keep specific subjects,
 %                   use 'rmvarvalues' and 'keepvarvalues'
 %   'checkeventtype' - [cell|array|string] check event type are present.
 %   'numeventrange' - [min max] range for number of event of type above.


### PR DESCRIPTION
Ensure backwards compatibility for `homogenous` → `homogeneous`.

See also:
* [What is the difference between homogenous and homogeneous?](https://www.quora.com/What-is-the-difference-between-homogenous-and-homogeneous)
* [Homogenous vs. Homogeneous](https://www.grammar.com/homogenous_vs._homogeneous)
* [Homogenous vs. Homogeneous – What’s the Difference?](https://writingexplained.org/homogenous-vs-homogeneous)
* [homogeneous](https://www.dictionary.com/browse/homogeneous) / [homogenous](https://www.dictionary.com/browse/homogenous) in Dictionary.com

The proper spelling here is _homogeneous_, although _homogenous_ has become quite common in everyday usage:
*  [232 000 000 hits](https://www.google.com/search?q=homogeneous) for _homogeneous_
*  [72 700 000 hits](https://www.google.com/search?q=homogenous) for _homogenous_