### PR TITLE
pop_delset: fix output to command history

### DIFF
--- a/functions/adminfunc/pop_delset.m
+++ b/functions/adminfunc/pop_delset.m
@@ -86,5 +86,5 @@ for i = set_in
 end
     
 % command = sprintf('%s = pop_delset( %s, [%s] );', inputname(1), inputname(1), int2str(set_in));
-command = sprintf('EEG = pop_delset( EEG, [%s] );', int2str(set_in));
+command = sprintf('ALLEEG = pop_delset( ALLEEG, [%s] );', int2str(set_in));
 return;


### PR DESCRIPTION
I tried to run the output of `eegh` in my script and it failed.

I took a look at the source code, and a couple of issues/PRs:
https://github.com/sccn/eeglab/issues/517
https://github.com/sccn/eeglab/pull/366

It seems to me that `ALLSET` <=> `ALLEEG`, rather than `EEG`, for the purpose of writing to `command`.