### PR TITLE
Optimal kmeans clustering

### DIFF
--- a/functions/studyfunc/optimal_kmeans.m
+++ b/functions/studyfunc/optimal_kmeans.m
@@ -1,0 +1,46 @@
+function [IDX, C, sumd, D] = optimal_kmeans(clustdata, clusnum)
+% THe aim of this function is to find the optimal number of clusters based
+% on the "clusdata" and the "clusnum" range.
+% INPUT: 
+%       clustdata: the data matrix for the componenets. It is the same
+%       varuable used in EEGLAB pop_clus.m
+%       clusnum: number of cluster is a [1 x 2] vector specifying the lower
+%       and upper bound of the optimal kmeans search.
+%
+% NOTE: This fucntion uses MALTAB's Statistics and Machine Learning
+% Toolbox, and can't run without that.
+%
+% Created by Seyed Yahya Shirazi @ UCF 2019
+
+%% intialize
+if size(clusnum,2) ~= 2
+    error('when using OPTIMAL_KMEANS, clusnum shoub be a 1x2 vector')
+end
+
+% try
+% clust = parcluster;
+% clust.NumWorkers = clust.NumWorkers - 2;
+% parpool(clust);
+% catch
+% end
+
+%% evaluate
+disp('Finding optimal number of clusters. please be patient \n')
+tic
+eva = evalclusters(clustdata,@par_kmeans,'silhouette','KList',clusnum(1):clusnum(2));
+toc
+[IDX,C, sumd, D] = kmeans(clustdata,eva.OptimalK,'Replicates',10);  
+
+end % end of the main funtion
+
+function C = par_kmeans(DATA,K)
+%     if gpuDeviceCount
+%         disp('using GPU for kmeans')
+%         X = gpuArray(DATA);
+%         gC = kmeans(X,K,'Replicates',10);
+%         C = gather(gC);
+%     else
+%         disp('using parpool for kmeans')
+        C = kmeans(DATA,K,'Replicates',5); % ,'Options',statset('UseParallel',1)     
+%     end
+end % end of function

--- a/functions/studyfunc/robust_kmeans.m
+++ b/functions/studyfunc/robust_kmeans.m
@@ -29,7 +29,7 @@
 % ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 % THE POSSIBILITY OF SUCH DAMAGE.
 
-function  [IDX,C,sumd,D,outliers] = robust_kmeans(data,N,STD,MAXiter,method)
+function  [IDX,C,sumd,D,outliers] = robust_kmeans(data,clus_num,STD,MAXiter,method)
 % data - pre-clustering data matrix.
 % N - number of wanted clusters.
 
@@ -41,9 +41,11 @@ flag  = 1;
 not_outliers = 1:size(data,1);
 old_outliers = [];
 if strcmpi(method, 'kmeans')
-    [IDX,C,sumd,D] = kmeans(data,N,'replicates',30,'emptyaction','drop'); % Cluster using K-means algorithm
+    [IDX,C,sumd,D] = kmeans(data,clus_num,'replicates',30,'emptyaction','drop'); % Cluster using K-means algorithm
+elseif strcmpi(method,'optimal_kmeans')
+    [IDX,C,sumd,D] = optimal_kmeans(data,clus_num); % Cluster using optimal K-menas
 else
-    [IDX,C,sumd,D] = kmeanscluster(data,N); % Cluster using K-means algorithm
+    [IDX,C,sumd,D] = kmeanscluster(data,clus_num); % Cluster using K-means algorithm
 end;    
 if STD >= 2 % STD for returned outlier
     rSTD = STD -1;
@@ -56,6 +58,7 @@ while flag
      loop =  loop + 1;
 	std_all = [];
     ref_D = 0;
+    N = size(C,1); % Should be dynamically assigned because of "optimal_kmeans"
 	for k = 1:N
         tmp = ['cls' num2str(k) ' = find(IDX=='  num2str(k) ')''; ' ]; %find the component indices belonging to each cluster (cls1 = ...).
         eval(tmp);
@@ -101,6 +104,8 @@ while flag
     
     if strcmpi(method, 'kmeans')
         [IDX,C,sumd,D] = kmeans(data(not_outliers,:),N,'replicates',30,'emptyaction','drop');
+    elseif strcmpi(method,'optimal_kmeans')
+        [IDX,C,sumd,D] = optimal_kmeans(data(not_outliers,:),clus_num);
     else
         [IDX,C,sumd,D] = kmeanscluster(data(not_outliers,:),N);
     end


### PR DESCRIPTION
Optimal K-Means clustering makes the choice of cluster numbers more objective by providing the option to give a range for the number of clusters in the clustering process.

The optimal K-means algorithm then tries all cluster numbers in the range and quantifies the clustering quality metric using MALTAB's `evalcluster` method (requires Statistics and ML toolbox) and the `silhouette` metric to find the optimal cluster count.

The algorithm works both from the GUI and the command line, but the user must pass a vector for the number of clusters to compute. The vector acts as [min max] number to determine the optimal cluster count:
![Screenshot 2024-07-10 at 3 36 20 PM](https://github.com/sccn/eeglab/assets/44906843/65e29d09-841e-44e1-981a-997be1ec1bfd)

The algorithm also works with the `robust_kmeas` algorithm, so the user can specify the threshold to determine the outliers: 
![Screenshot 2024-07-10 at 3 38 05 PM](https://github.com/sccn/eeglab/assets/44906843/ff527587-d1e7-4b1b-9a87-4549a25fa64e)
