### PR TITLE
Fix font rendering in event marker text display

### DIFF
--- a/functions/sigprocfunc/eegplot.m
+++ b/functions/sigprocfunc/eegplot.m
@@ -1546,7 +1546,7 @@ else
         for index = 1:length(event2plot)
             %Just repeat for the first one
             if index == 1
-                EVENTFONT = ' \fontsize{10} ';
+                EVENTFONT = '  ';
             end
             
             % draw latency line
@@ -1564,6 +1564,7 @@ else
             if length(evntxt)>MAXEVENTSTRING, evntxt = [ evntxt(1:MAXEVENTSTRING-1) '...' ]; end % truncate
             try, 
                 tmph2 = text(ax0, [tmplat], ylims(2)-0.005, [EVENTFONT evntxt], ...
+				    'fontsize', 10, ...
                                     'color', g.eventcolors{ event2plot(index) }, ...
                                     'horizontalalignment', 'left',...
                                     'rotation',90);


### PR DESCRIPTION
Issue Fixed The original code used TeX markup (\fontsize{10}) which displays incorrectly in modern MATLAB versions, showing the literal markup text instead of applying the font size.
Changes Made
	•	Replaced \fontsize{10} TeX markup with direct ‘FontSize’ property setting
	•	Modified EVENTFONT variable to use two spaces for consistent spacing
	•	Added explicit FontSize property to text object creation
Compatibility
	•	Works in MATLAB R2022b and later versions
	•	Maintains backward compatibility with existing functionality
	•	Follows modern MATLAB text property conventions
	
![CleanShot 2025-02-05 at 15 52 43](https://github.com/user-attachments/assets/721a18e6-a035-448d-b116-79906e4edd6d)