### PR TITLE
tftopo: fix check for data and times sizes, indeed allow for multiples

### DIFF
--- a/functions/miscfunc/tftopo.m
+++ b/functions/miscfunc/tftopo.m
@@ -181,9 +181,9 @@ if ischar(g), error(g); end
 
 % setting more defaults
 % ---------------------
-if length(times) ~= size(tfdata,2)
-   fprintf('tftopo(): tfdata columns must be a multiple of the length of times (%d)\n',...
-                 length(times));
+if mod(size(tfdata,2),length(times)) ~= 0
+   fprintf('tftopo(): tfdata columns must be a multiple of the length of times (%d vs %d)\n',...
+                    size(tfdata,2), length(times));
    return
 end
 if length(g.showchan) > 1


### PR DESCRIPTION
Hello,

I have data with both within-subjects and between-subjects conditions, over several sessions. While running ERSP analyses I faced an error message due to the way data got formatted. Since the message talks about multiples I *believe* I fixed the intended behavior -- I did not went through the entire code looking for side effects but the the output seems consistent with analyses that do not take into account the sessions.