### PR TITLE
Fix typos in help text

### DIFF
--- a/Contents.m
+++ b/Contents.m
@@ -22,5 +22,5 @@
 %   Matlab scripts.  A single data structure ('EEG') containing all dataset 
 %   parameters may be accessed and modified directly from the Matlab commandline. 
 %   EEGLAB now recognizes "plugins," sets of EEGLAB functions linked to the EEGLAB
-%   main menu through an "eegplugin_[name].m" function (Ex. >> help eeplugin_besa.m). 
+%   main menu through an "eegplugin_[name].m" function (Ex. >> help eegplugin_besa.m).
 %

--- a/eeglab.m
+++ b/eeglab.m
@@ -20,12 +20,12 @@
 %   Matlab scripts.  A single data structure ('EEG') containing all dataset 
 %   parameters may be accessed and modified directly from the Matlab commandline. 
 %   EEGLAB now recognizes "plugins," sets of EEGLAB functions linked to the EEGLAB
-%   main menu through an "eegplugin_[name].m" function (Ex. >> help eeplugin_besa.m). 
+%   main menu through an "eegplugin_[name].m" function (Ex. >> help eegplugin_besa.m).
 %
 % Usage: 1) To (re)start EEGLAB, type
 %            >> eeglab           % Ignores any loaded datasets
 %            >> eeglab nogui     % Do not pop up GUI
-%        2) To redaw and update the EEGLAB interface, type
+%        2) To redraw and update the EEGLAB interface, type
 %            >> eeglab redraw    % Scans for non-empty datasets
 %            >> eeglab rebuild   % Closes and rebuilds the EEGLAB window
 %            >> eeglab versions  % State EEGLAB version number

--- a/functions/timefreqfunc/pac_cont.m
+++ b/functions/timefreqfunc/pac_cont.m
@@ -137,7 +137,7 @@ end
 if ndims(X) == 3 || ndims(Y) == 3, error('Cannot process 3-D input'); end
 if size(X,1) > 1, X = X'; end
 if size(Y,1) > 1, Y = Y'; end
-if size(X,1) ~= 1 || size(Y,1) ~= 1, error('Cannot only process vector input'); end
+if size(X,1) ~= 1 || size(Y,1) ~= 1, error('Can only process vector input'); end
 frame = size(X,2);
 pvals = [];
 


### PR DESCRIPTION
## Summary
- correct typos in `eeglab.m` and `Contents.m`
- fix grammar in `pac_cont` error message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866333819248325994b6b24d2b30cd5