### PR TITLE
fix event description when loading data with biosig

### DIFF
--- a/functions/popfunc/pop_biosig.m
+++ b/functions/popfunc/pop_biosig.m
@@ -274,8 +274,8 @@ for iFile = 1:length(filename)
         
         %Get correct event names contained in CodeDesc
         num_ev_type = unique(HDR.EVENT.TYP);
-        num_ev_name = unique(HDR.EVENT.CodeDesc);
-        if ~isempty(HDR.EVENT.CodeDesc) && length(num_ev_type) == length(num_ev_name)
+        if isfield(HDR.EVENT,'CodeDesc') && ~isempty(HDR.EVENT.CodeDesc) && length(num_ev_type) == length(num_ev_name)
+            num_ev_name = unique(HDR.EVENT.CodeDesc);
             for iEvent = 1:length(HDR.EVENT.TYP)
                 EEG.event(iEvent).type = char(HDR.EVENT.CodeDesc(HDR.EVENT.TYP(iEvent)));
                 EEG.event(iEvent).latency = HDR.EVENT.POS(iEvent);

--- a/functions/sigprocfunc/biosig2eeglabevent.m
+++ b/functions/sigprocfunc/biosig2eeglabevent.m
@@ -67,10 +67,7 @@ if isempty(interval)
             % use file in
             % https://sccn.ucsd.edu/bugzilla/show_bug.cgi?id=1387 to test
             % for boundary events
-            if eType < 256 && importEDFplus && isfield(EVENT,'CodeDesc') && eType < length(EVENT.CodeDesc)
-                event(index).type = EVENT.CodeDesc{eType};
-                event(index).edftype = eType;
-            elseif isfield(EVT, 'EVENT') && isfield(EVT.EVENT,'CodeIndex') && isfield(EVT.EVENT,'CodeDesc') && importEDFplus
+            if isfield(EVT, 'EVENT') && isfield(EVT.EVENT,'CodeIndex') && isfield(EVT.EVENT,'CodeDesc') && importEDFplus && (eType > 255)
                 try
                     event(index).type = EVT.EVENT.CodeDesc{EVT.EVENT.CodeIndex==eType};
                     event(index).edftype = eType;
@@ -117,10 +114,7 @@ elseif isfield(EVENT,'POS')
                 eType = EVENT.TYP(index);
 
                 if isfield(EVENT, 'CodeDesc')
-                    if eType < 256 && importEDFplus && eType < length(EVENT.CodeDesc)
-                        event(index).type = EVENT.CodeDesc{eType};
-                        event(index).edftype = eType;
-                    elseif isfield(EVT, 'EVENT') && isfield(EVT.EVENT,'CodeIndex') && isfield(EVT.EVENT,'CodeDesc') && importEDFplus
+                    if isfield(EVT, 'EVENT') && isfield(EVT.EVENT,'CodeIndex') && isfield(EVT.EVENT,'CodeDesc') && importEDFplus && (eType > 255)
                         try
                             event(index).type = EVT.EVENT.CodeDesc{EVT.EVENT.CodeIndex==eType};
                             event(index).edftype = eType;


### PR DESCRIPTION
that pull request handles events in a more senible way. 

- when using mexSLOAD, the event handling is broken
- when using sload/sread/sclose, the user defined events (1-255) are not consistenly described, some get prefixed with "condition ..", others not. 

The this PR addresses both case.s   